### PR TITLE
CAL-881 - Client Commands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: callistor
 Title: Callisto R Kernel Library
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(
     person(given = "Taylor",
            family = "Harrison",

--- a/R/client_commands.R
+++ b/R/client_commands.R
@@ -32,7 +32,7 @@ open_settings <- function(page=NULL) {
         command <- paste(URL_SETTINGS, "/", page, sep="")
         send_url_command(command)
     } else {
-        stop("That is not a valid page")
+        stop(paste("'", page, "'", " is not a valid page", sep=""))
     }
 }
 

--- a/R/client_commands.R
+++ b/R/client_commands.R
@@ -1,0 +1,57 @@
+
+D1_COMMAND_DELIMITER <- "___callisto_d1_command___"
+
+URL_DATA_EXPLORER <- "com.callistoapp.callisto://ui/data-explorer"
+URL_SETTINGS <- "com.callistoapp.callisto://ui/settings"
+URL_CLOUD_BROWSER <- "com.callistoapp.callisto://ui/cloud"
+URL_PACKAGE_MANAGER <- "com.callistoapp.callisto://ui/xip"
+URL_NOTEBOOK_CHECK <- "com.callistoapp.callisto://ui/notebook-check"
+URL_CLIENT_LOG <- "com.callistoapp.callisto://ui/client-log"
+URL_D1_LOG <- "com.callistoapp.callisto://ui/d1-log"
+
+allowed_settings_pages <- c(
+    "editor", "notebook", "r", "account", "advanced"
+)
+
+send_url_command <- function(url) {
+    command <- list()
+    command[["command_type"]] <- "client_command_url"
+    command[["url"]] <- url
+    msg <- paste(D1_COMMAND_DELIMITER, rjson::toJSON(command), D1_COMMAND_DELIMITER, sep="")
+    write(msg, stdout())
+}
+
+open_data_explorer <- function() {
+    send_url_command(URL_DATA_EXPLORER)
+}
+
+open_settings <- function(page=NULL) {
+    if (is.null(page)) {
+        send_url_command(URL_SETTINGS)
+    } else if (is.character(page) && tolower(page) %in% allowed_settings_pages) {
+        command <- paste(URL_SETTINGS, "/", page, sep="")
+        send_url_command(command)
+    } else {
+        stop("That is not a valid page")
+    }
+}
+
+open_cloud_browser <- function() {
+    send_url_command(URL_CLOUD_BROWSER)
+}
+
+open_package_manager <- function() {
+    send_url_command(URL_PACKAGE_MANAGER)
+}
+
+open_notebook_checker <- function() {
+    send_url_command(URL_NOTEBOOK_CHECK)
+}
+
+open_client_log <- function() {
+    send_url_command(URL_CLIENT_LOG)
+}
+
+open_d1_log <- function() {
+    send_url_command(URL_D1_LOG)
+}

--- a/tests/testthat/test_client_commands.R
+++ b/tests/testthat/test_client_commands.R
@@ -61,11 +61,11 @@ test_that("settings command with specific page 'r'", {
 test_that("settings command with invalid page", {
     expect_error(
         open_settings("bad"),
-        "That is not a valid page"
+        "'bad' is not a valid page"
     )
     expect_error(
         open_settings("advance"),
-        "That is not a valid page"
+        "'advance' is not a valid page"
     )
 })
 

--- a/tests/testthat/test_client_commands.R
+++ b/tests/testthat/test_client_commands.R
@@ -1,0 +1,145 @@
+test_that("data explorer command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/data-explorer"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_data_explorer(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("settings command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/settings"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_settings(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("settings command with specific page 'advanced'", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/advanced"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_settings("advanced"),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("settings command with specific page 'r'", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/r"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_settings("R"),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("settings command with invalid page", {
+    expect_error(
+        open_settings("bad"),
+        "That is not a valid page"
+    )
+    expect_error(
+        open_settings("advance"),
+        "That is not a valid page"
+    )
+})
+
+test_that("cloud browser command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/cloud"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_cloud_browser(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("package manager command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/xip"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_package_manager(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("notebook checker command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://ui/notebook-check"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_notebook_checker(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("client log command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://debug/client-log"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_client_log(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})
+
+test_that("d1 log command", {
+    expected_value <- '___callisto_d1_command___
+      {
+        "command_type":"client_command_url",
+        "url":"com.callistoapp.callisto://debug/d1-log"
+      }
+      ___callisto_d1_command___'
+
+    expect_output(
+      open_d1_log(),
+      cat(expected_value),
+      fixed=TRUE
+    )
+})


### PR DESCRIPTION
added the same functions as callisto-python for sending command URLs to the client via D1